### PR TITLE
[DEAD] Improve SkipLast

### DIFF
--- a/MoreLinq.Test/SkipLastTest.cs
+++ b/MoreLinq.Test/SkipLastTest.cs
@@ -32,12 +32,25 @@ namespace MoreLinq.Test
         }
 
         [Test]
-        public void SkipLast()
+        public void SkipLastEnumerable()
         {
             const int take = 100;
             const int skip = 20;
 
             var sequence = Enumerable.Range(1, take);
+
+            var expectations = sequence.Take(take - skip);
+
+            Assert.That(expectations, Is.EqualTo(sequence.SkipLast(skip)));
+        }
+
+        [Test]
+        public void SkipLastCollection()
+        {
+            const int take = 100;
+            const int skip = 20;
+
+            var sequence = Enumerable.Range(1, take).ToArray();
 
             var expectations = sequence.Take(take - skip);
 

--- a/MoreLinq/SkipLast.cs
+++ b/MoreLinq/SkipLast.cs
@@ -40,12 +40,26 @@ namespace MoreLinq
             if (count < 1)
                 return source;
 
-            return
-                source.TryGetCollectionCount() is int collectionCount
-                ? source.Take(collectionCount - count)
-                : source.CountDown(count, (e, cd) => (Element: e, Countdown: cd ))
-                        .TakeWhile(e => e.Countdown == null)
-                        .Select(e => e.Element);
+            var collectionCount = source.TryGetCollectionCount();
+            if (collectionCount.HasValue)
+                return source.Take(collectionCount.Value - count);
+
+            return _(); IEnumerable<T> _()
+            {
+                var queue = new Queue<T>(count);
+                using var enumerator = source.GetEnumerator();
+
+                while (count-- > 0 && enumerator.MoveNext())
+                {
+                    queue.Enqueue(enumerator.Current);
+                }
+
+                while (enumerator.MoveNext())
+                {
+                    yield return queue.Dequeue();
+                    queue.Enqueue(enumerator.Current);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Branch to fix #626.

We can avoid to consume the full sequence.
We only need `O(skipCount)` in memory.
The proposed implementation will not fail on an infinite sequence.