### PR TITLE
[DEAD] Improve Window, WindowLeft and WindowRight

### DIFF
--- a/MoreLinq.Test/WindowLeftTest.cs
+++ b/MoreLinq.Test/WindowLeftTest.cs
@@ -35,7 +35,7 @@ namespace MoreLinq.Test
             const int count = 100;
             var sequence = Enumerable.Range(1, count).ToArray();
 
-            IList<int>[] result;
+            IReadOnlyList<int>[] result;
             using (var ts = sequence.AsTestingSequence())
                 result = ts.WindowLeft(1).ToArray();
 

--- a/MoreLinq.Test/WindowRightTest.cs
+++ b/MoreLinq.Test/WindowRightTest.cs
@@ -35,7 +35,7 @@ namespace MoreLinq.Test
             const int count = 100;
             var sequence = Enumerable.Range(1, count).ToArray();
 
-            IList<int>[] result;
+            IReadOnlyList<int>[] result;
             using (var ts = sequence.AsTestingSequence())
                 result = ts.WindowRight(1).ToArray();
 

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -6706,7 +6706,7 @@ namespace MoreLinq.Extensions
         /// ]]></code>
         /// </example>
 
-        public static IEnumerable<IList<TSource>> WindowLeft<TSource>(this IEnumerable<TSource> source, int size)
+        public static IEnumerable<IReadOnlyList<TSource>> WindowLeft<TSource>(this IEnumerable<TSource> source, int size)
             => MoreEnumerable.WindowLeft(source, size);
 
     }
@@ -6751,7 +6751,7 @@ namespace MoreLinq.Extensions
         /// ]]></code>
         /// </example>
 
-        public static IEnumerable<IList<TSource>> WindowRight<TSource>(this IEnumerable<TSource> source, int size)
+        public static IEnumerable<IReadOnlyList<TSource>> WindowRight<TSource>(this IEnumerable<TSource> source, int size)
             => MoreEnumerable.WindowRight(source, size);
 
     }

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -6661,7 +6661,7 @@ namespace MoreLinq.Extensions
         /// <param name="size">The size (number of elements) in each window</param>
         /// <returns>A series of sequences representing each sliding window subsequence</returns>
 
-        public static IEnumerable<IList<TSource>> Window<TSource>(this IEnumerable<TSource> source, int size)
+        public static IEnumerable<IReadOnlyList<TSource>> Window<TSource>(this IEnumerable<TSource> source, int size)
             => MoreEnumerable.Window(source, size);
 
     }

--- a/MoreLinq/WindowRight.cs
+++ b/MoreLinq/WindowRight.cs
@@ -58,34 +58,19 @@ namespace MoreLinq
         /// ]]></code>
         /// </example>
 
-        public static IEnumerable<IList<TSource>> WindowRight<TSource>(this IEnumerable<TSource> source, int size)
+        public static IEnumerable<IReadOnlyList<TSource>> WindowRight<TSource>(this IEnumerable<TSource> source, int size)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (size < 0) throw new ArgumentOutOfRangeException(nameof(size));
 
-            return source.WindowRightWhile((_, i) => i < size);
-        }
-
-        /// <summary>
-        /// Creates a right-aligned sliding window over the source sequence
-        /// with a predicate function determining the window range.
-        /// </summary>
-
-        static IEnumerable<IList<TSource>> WindowRightWhile<TSource>(
-            this IEnumerable<TSource> source,
-            Func<TSource, int, bool> predicate)
-        {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
-
-            return _(); IEnumerable<IList<TSource>> _()
+            return _(); IEnumerable<IReadOnlyList<TSource>> _()
             {
-                var window = new List<TSource>();
-                foreach (var item in source)
+                var cache = new List<TSource>();
+                var offset = -size;
+                foreach (var element in source)
                 {
-                    window.Add(item);
-                    yield return window;
-                    window = new List<TSource>(predicate(item, window.Count) ? window : window.Skip(1));
+                    cache.Add(element);
+                    yield return new WindowedList<TSource>(cache, Math.Max(0, ++offset), Math.Min(size, cache.Count));
                 }
             }
         }

--- a/MoreLinq/WindowedList.cs
+++ b/MoreLinq/WindowedList.cs
@@ -1,0 +1,58 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2008 Jonathan Skeet. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+
+    internal class WindowedList<T> : IReadOnlyList<T>
+    {
+        private readonly IReadOnlyList<T> _source;
+        private readonly int _offset;
+
+        public WindowedList(IReadOnlyList<T> source, int offset, int size)
+        {
+            _source = source;
+            _offset = offset;
+            Count = size;
+        }
+
+        public T this[int index]
+        {
+            get
+            {
+                if (index < 0 || index >= Count)
+                    throw new ArgumentOutOfRangeException(nameof(index));
+                return _source[index + _offset];
+            }
+        }
+
+        public int Count { get; }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            for (var i = 0; i < Count; i++)
+            {
+                yield return this[i];
+            }
+        }
+    }
+}


### PR DESCRIPTION
The branch is here to fix #627.

`Window`, `WindowLeft` and `WindowRight` take `O(sourceSize*windowSize)` in memory.
If we accept that the method returns `IEnumerable<IReadOnlyList<TSource>>` instead of `IEnumerable<IList<TSource>>`, we can go down to `O(consumedElement)` < `O(sourceSize)`.